### PR TITLE
Adding an OptionsBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ let default_options = Options::default();
 let default_client = Client::new(default_options).unwrap();
 
 // Binds to 127.0.0.1:9000 for transmitting and sends to 10.1.2.3:8125, with a
-// namespace of "analytics".
-let custom_options = Options::new("127.0.0.1:9000", "10.1.2.3:8125", "analytics");
+// namespace of "analytics", and a default tag of "region:west".
+let custom_options = Options::new("127.0.0.1:9000", "10.1.2.3:8125", "analytics", "region:west");
 let custom_client = Client::new(custom_options).unwrap();
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,124 @@ impl Options {
     }
 }
 
+/// Struct that allows build an `Options` for available for the Dogstatsd client.
+#[derive(Debug)]
+pub struct OptionsBuilder {
+    /// The address of the udp socket we'll bind to for sending.
+    from_addr: Option<String>,
+    /// The address of the udp socket we'll send metrics and events to.
+    to_addr: Option<String>,
+    /// A namespace to prefix all metrics with, joined with a '.'.
+    namespace: Option<String>,
+    /// Default tags to include with every request.
+    default_tags: Vec<String>
+}
+
+impl OptionsBuilder {
+    /// Create a new `OptionsBuilder` struct.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    ///   use dogstatsd::OptionsBuilder;
+    ///
+    ///   let options_builder = OptionsBuilder::new();
+    /// ```
+    pub fn new() -> Self {
+        Self {
+            from_addr: Option::None,
+            to_addr: Option::None,
+            namespace: Option::None,
+            default_tags: Vec::new()
+        }
+    }
+
+    /// Will allow the builder to generate an `Options` struct with the provided value.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    ///   use dogstatsd::OptionsBuilder;
+    ///
+    ///   let options_builder = OptionsBuilder::new().from_addr(String::from("127.0.0.1:9000"));
+    /// ```
+    pub fn from_addr<'a>(&'a mut self, from_addr: String) -> &'a mut OptionsBuilder {
+        self.from_addr = Some(from_addr);
+        self
+    }
+
+    /// Will allow the builder to generate an `Options` struct with the provided value.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    ///   use dogstatsd::OptionsBuilder;
+    ///
+    ///   let options_builder = OptionsBuilder::new().to_addr(String::from("127.0.0.1:9001"));
+    /// ```
+    pub fn to_addr<'a>(&'a mut self, to_addr: String) -> &'a mut OptionsBuilder {
+        self.to_addr = Some(to_addr);
+        self
+    }
+
+    /// Will allow the builder to generate an `Options` struct with the provided value.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    ///   use dogstatsd::OptionsBuilder;
+    ///
+    ///   let options_builder = OptionsBuilder::new().namespace(String::from("mynamespace"));
+    /// ```
+    pub fn namespace<'a>(&'a mut self, namespace: String) -> &'a mut OptionsBuilder {
+        self.namespace = Some(namespace);
+        self
+    }
+
+    /// Will allow the builder to generate an `Options` struct with the provided value. Can be called multiple times to add multiple `default_tags` to the `Options`.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    ///   use dogstatsd::OptionsBuilder;
+    ///
+    ///   let options_builder = OptionsBuilder::new().default_tag(String::from("tag1:tav1val")).default_tag(String::from("tag2:tag2val"));
+    /// ```
+    pub fn default_tag<'a>(&'a mut self, default_tag: String) -> &'a mut OptionsBuilder {
+        self.default_tags.push(default_tag);
+        self
+    }
+
+    /// Will construct an `Options` with all of the provided values and fall back to the default values if they aren't provided.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    ///   use dogstatsd::OptionsBuilder;
+    ///   use dogstatsd::Options;
+    ///
+    ///   let options = OptionsBuilder::new().namespace(String::from("mynamespace")).default_tag(String::from("tag1:tav1val")).build();
+    /// 
+    ///   assert_eq!(
+    ///       Options {
+    ///           from_addr: "127.0.0.1:0".into(),
+    ///           to_addr: "127.0.0.1:8125".into(),
+    ///           namespace: String::from("mynamespace"),
+    ///           default_tags: vec!(String::from("tag1:tav1val"))
+    ///       },
+    ///       options
+    ///   )
+    /// ```
+    pub fn build(&self) -> Options {
+        Options::new(
+            &self.from_addr.as_ref().unwrap_or(&String::from("127.0.0.1:0")),
+            &self.to_addr.as_ref().unwrap_or(&String::from("127.0.0.1:8125")),
+            &self.namespace.as_ref().unwrap_or(&String::default()),
+            self.default_tags.to_vec()
+        )
+    }
+}
+
 /// The client struct that handles sending metrics to the Dogstatsd server.
 #[derive(Debug)]
 pub struct Client {
@@ -454,6 +572,37 @@ mod tests {
         };
 
         assert_eq!(expected_options, options)
+    }
+
+    #[test]
+    fn test_options_builder_none() {
+        let options = OptionsBuilder::new().build();
+        let expected_options = Options {
+            from_addr: "127.0.0.1:0".into(),
+            to_addr: "127.0.0.1:8125".into(),
+            namespace: String::new(),
+            ..Default::default()
+        };
+
+        assert_eq!(expected_options, options);
+    }
+
+    #[test]
+    fn teset_options_builder_all() {
+        let options = OptionsBuilder::new()
+            .from_addr("127.0.0.2:0".into())
+            .to_addr("127.0.0.2:8125".into())
+            .namespace("mynamespace".into())
+            .default_tag(String::from("tag1:tag1val"))
+            .build();
+        let expected_options = Options {
+            from_addr: "127.0.0.2:0".into(),
+            to_addr: "127.0.0.2:8125".into(),
+            namespace: "mynamespace".into(),
+            default_tags: vec!("tag1:tag1val".into()).to_vec()
+        };
+
+        assert_eq!(expected_options, options);
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 
-pub fn format_for_send<M, I, S>(in_metric: &M, in_namespace: &str, tags: I) -> Vec<u8>
+pub fn format_for_send<M, I, S>(in_metric: &M, in_namespace: &str, tags: I, default_tags: &Vec<u8>) -> Vec<u8>
     where M: Metric,
           I: IntoIterator<Item=S>,
           S: AsRef<str>,
@@ -35,6 +35,11 @@ pub fn format_for_send<M, I, S>(in_metric: &M, in_namespace: &str, tags: I) -> V
         if next_tag.is_some() {
             buf.extend_from_slice(b",");
         }
+    }
+
+    if !default_tags.is_empty() {
+        buf.extend_from_slice(b",");
+        buf.extend_from_slice(&default_tags);
     }
 
     buf
@@ -390,7 +395,7 @@ mod tests {
     fn test_format_for_send_no_tags() {
         assert_eq!(
             &b"namespace.foo:1|c"[..],
-            &format_for_send(&CountMetric::Incr("foo"), "namespace", &[] as &[String])[..]
+            &format_for_send(&CountMetric::Incr("foo"), "namespace", &[] as &[String], &String::default().into_bytes())[..]
         )
     }
 
@@ -398,15 +403,23 @@ mod tests {
     fn test_format_for_send_no_namespace() {
         assert_eq!(
             &b"foo:1|c|#tag:1,tag:2"[..],
-            &format_for_send(&CountMetric::Incr("foo"), "", &["tag:1", "tag:2"])[..]
+            &format_for_send(&CountMetric::Incr("foo"), "", &["tag:1", "tag:2"], &String::default().into_bytes())[..]
+        )
+    }
+
+    #[test]
+    fn test_format_for_no_default_tags() {
+        assert_eq!(
+            &b"namespace.foo:1|c|#tag:1,tag:2,defaultag:3,seconddefault:4"[..],
+            &format_for_send(&CountMetric::Incr("foo"), "namespace", &["tag:1", "tag:2"], &String::from("defaultag:3,seconddefault:4").into_bytes())[..]
         )
     }
 
     #[test]
     fn test_format_for_send_everything() {
         assert_eq!(
-            &b"namespace.foo:1|c|#tag:1,tag:2"[..],
-            &format_for_send(&CountMetric::Incr("foo"), "namespace", &["tag:1", "tag:2"])[..]
+            &b"namespace.foo:1|c|#tag:1,tag:2,defaultag:3,seconddefault:4"[..],
+            &format_for_send(&CountMetric::Incr("foo"), "namespace", &["tag:1", "tag:2"], &String::from("defaultag:3,seconddefault:4").into_bytes())[..]
         )
     }
 
@@ -414,7 +427,7 @@ mod tests {
     fn test_format_for_send_everything_omit_namespace() {
         assert_eq!(
             &b"_e{5,4}:title|text|#tag:1,tag:2"[..],
-            &format_for_send(&Event::new("title".into(), "text".into()), "namespace", &["tag:1", "tag:2"])[..]
+            &format_for_send(&Event::new("title".into(), "text".into()), "namespace", &["tag:1", "tag:2"], &String::default().into_bytes())[..]
         )
     }
 


### PR DESCRIPTION
Adding an `OptionsBuilder` so future changes on the `Options` struct don't require changes code changes for anyone using the library.

Just in draft since it's currently pointing to a PR that isn't merged upstream yet.